### PR TITLE
fix(wayland-protocols): minimum version

### DIFF
--- a/wayland/CMakeLists.txt
+++ b/wayland/CMakeLists.txt
@@ -8,7 +8,7 @@ pkg_check_modules(xkbcommon REQUIRED xkbcommon)
 
 # Wayland protocols
 find_program(WAYLAND_SCANNER_EXECUTABLE NAMES wayland-scanner)
-pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.15)
+pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols>=1.25)
 pkg_get_variable(WAYLAND_PROTOCOLS_BASE wayland-protocols pkgdatadir)
 
 macro(wayland_generate protocol_xml_file output_dir target)


### PR DESCRIPTION
wayland driver needs configure_bounds and it was introduced on version 1.25: https://github.com/wayland-project/wayland-protocols/commit/344048614ad4a3887e431f63b6f12208edce51f9